### PR TITLE
add RZZ and Reset operations

### DIFF
--- a/pytket/extensions/azure/backends/azure.py
+++ b/pytket/extensions/azure/backends/azure.py
@@ -60,6 +60,8 @@ _GATE_SET = {
     OpType.X,
     OpType.Y,
     OpType.Z,
+    OpType.ZZPhase,
+    OpType.Reset
 }
 
 


### PR DESCRIPTION
Adding native gates from qsharp to the _GATE_SET list:

1.  RZZ: https://learn.microsoft.com/en-us/qsharp/api/qsharp-lang/microsoft.quantum.intrinsic/rzz
2.  Reset: https://learn.microsoft.com/en-us/qsharp/api/qsharp-lang/microsoft.quantum.intrinsic/reset

Above, 1. is needed for arbitrary angle two-qubit gates and 2. is needed for MCMR.

# Related issues

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
