### PR TITLE
Don't publish docs to github pages

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -94,19 +94,3 @@ jobs:
       uses: actions/upload-pages-artifact@v3
       with:
         path: .github/workflows/docs/extensions
-
-  publish_docs:
-    name: Publish docs
-    if: github.event_name == 'release'
-    needs: build_docs
-    runs-on: 'ubuntu-latest'
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-    - name: Deploy to GitHub Pages
-      id: deployment
-      uses: actions/deploy-pages@v4.0.5


### PR DESCRIPTION
In line with other extensions, the docs should be published separately to the tket site. (Have made an issue for this.)

Closes #10 .