### PR TITLE
Don't bump major version of pytket when testing with pytket pre-release

### DIFF
--- a/.github/workflows/build-test
+++ b/.github/workflows/build-test
@@ -14,7 +14,7 @@ set -evu
 # WARNING: running this locally will delete any local files that
 # aren't strictly part of the git tree, including gitignored files!
 
-MODULE=pytket-iqm
+MODULE=pytket-azure
 
 MYPY=$1
 

--- a/.github/workflows/build-test
+++ b/.github/workflows/build-test
@@ -51,8 +51,10 @@ cd ${GITHUB_WORKSPACE}/tests
 
 python -m pip install --pre -r test-requirements.txt
 
-# update the pytket version to the lastest (pre) release
-python -m pip install --upgrade --pre pytket
+# Update the pytket version to the lastest (pre) release. But don't bump the
+# major version.
+python -m pip install importlib_metadata
+python -m pip install --upgrade --pre "pytket<`python -c \"from importlib_metadata import version; print(int(version('pytket').split('.')[0])+1)\"`"
 
 pytest --doctest-modules
 

--- a/pytket/extensions/azure/__init__.py
+++ b/pytket/extensions/azure/__init__.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Backends for processing pytket circuits with Azure devices
-"""
+"""Backends for processing pytket circuits with Azure devices"""
 
 # _metadata.py is copied to the folder after installation.
 from ._metadata import __extension_name__, __extension_version__

--- a/pytket/extensions/azure/backends/__init__.py
+++ b/pytket/extensions/azure/backends/__init__.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Backends for processing pytket circuits with Azure devices
-"""
+"""Backends for processing pytket circuits with Azure devices"""
 
 from .azure import AzureBackend
 from .config import AzureConfig, set_azure_config


### PR DESCRIPTION
May need to make this change in a few other repos.