### PR TITLE
Add docs coverage and warning checks to CI and resolve failures for both

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: '0'
-        submodules: true
+        submodules: recursive
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* +refs/heads/*:refs/remotes/origin/*
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -34,15 +34,11 @@ jobs:
       run: ./.github/workflows/build-test mypy
     - name: install poetry
       run: pip install poetry
-    - name: Install docs dependencies
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        cd docs
-        bash ./install.sh
-        for w in `find wheelhouse/ -type f -name "*.whl"` ; do poetry install $w ; done
     - name: Build docs
       if: matrix.os == 'ubuntu-latest'
       timeout-minutes: 20
       run: |
         cd docs
+        bash ./install.sh
+        poetry run pip install ../.
         poetry run bash ./build-docs.sh

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,8 +2,15 @@ API documentation
 ~~~~~~~~~~~~~~~~~
 
 .. automodule:: pytket.extensions.azure
-    :special-members:
-    :members: AzureBackend
+
+.. automodule:: pytket.extensions.azure._metadata
+.. automodule:: pytket.extensions.azure.backends
+.. automodule:: pytket.extensions.azure.backends.azure
+
+   .. autoclass:: AzureBackend
+      :members:
+
+   .. autoclass:: DeviceType
 
 .. automodule:: pytket.extensions.azure.backends.config
     :members: AzureConfig, set_azure_config

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -13,7 +13,9 @@ EXTENSION_NAME="$(basename "$(dirname `pwd`)")"
 sed -i '' 's#CQCL/tket#CQCL/'$EXTENSION_NAME'#' _static/nav-config.js
 
 # Build the docs. Ensure we have the correct project title.
-sphinx-build -b html -D html_title="$EXTENSION_NAME" . build 
+sphinx-build -W -b html -D html_title="$EXTENSION_NAME" . build || exit 1
+
+sphinx-build -W -v -b coverage . build/coverage || exit 1
 
 # Remove copied files. This ensures reusability.
 rm -r _static 

--- a/pytket/extensions/azure/__init__.py
+++ b/pytket/extensions/azure/__init__.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Backends for processing pytket circuits with Azure devices"""
-
 # _metadata.py is copied to the folder after installation.
 from ._metadata import __extension_name__, __extension_version__
 from .backends import AzureBackend, AzureConfig, set_azure_config

--- a/pytket/extensions/azure/backends/__init__.py
+++ b/pytket/extensions/azure/backends/__init__.py
@@ -12,7 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Backends for processing pytket circuits with Azure devices"""
-
 from .azure import AzureBackend
 from .config import AzureConfig, set_azure_config

--- a/pytket/extensions/azure/backends/azure.py
+++ b/pytket/extensions/azure/backends/azure.py
@@ -346,7 +346,7 @@ using default compilation"
         **kwargs: KwargTypes,
     ) -> list[ResultHandle]:
         """
-        See :py:meth:`pytket.backends.Backend.process_circuits`.
+        See :py:meth:`pytket.backends.backend.Backend.process_circuits`.
 
         Supported kwargs:
 
@@ -470,7 +470,7 @@ using default compilation"
 
     def get_result(self, handle: ResultHandle, **kwargs: KwargTypes) -> BackendResult:
         """
-        See :py:meth:`pytket.backends.Backend.get_result`.
+        See :py:meth:`pytket.backends.backend.Backend.get_result`.
 
         Supported kwargs:
 
@@ -500,7 +500,7 @@ using default compilation"
     @cache
     def available_devices(cls, **kwargs: Any) -> list[BackendInfo]:
         """
-        See :py:meth:`pytket.backends.Backend.get_result`.
+        See :py:meth:`pytket.backends.backend.Backend.get_result`.
 
         Supported kwargs:
 

--- a/pytket/extensions/azure/backends/azure.py
+++ b/pytket/extensions/azure/backends/azure.py
@@ -228,7 +228,7 @@ using default compilation"
             prompting more computationally heavy optimising compilation that
             can lead to reduced gate count in circuits.
         :param timeout: Only valid for optimisation level 3, gives a maximimum time
-            for running a single thread of the pass `GreedyPauliSimp`. Increase for
+            for running a single thread of the pass :py:meth:`pytket.passes.GreedyPauliSimp`. Increase for
             optimising larger circuits.
 
         :return: Compilation pass for compiling circuits to Quantinuum devices
@@ -353,6 +353,9 @@ using default compilation"
         - option_params: a dictionary with string keys and arbitrary values;
           key-value pairs in the dictionary are passed as input parameters to
           the backend. Their semantics are backend-dependent.
+
+        :return: Handles to results for each input circuit, as an interable in
+            the same order as the circuits.
         """
         option_params = kwargs.get("option_params")
         circuits = list(circuits)
@@ -475,6 +478,8 @@ using default compilation"
         Supported kwargs:
 
         - timeout (int): timeout in seconds
+
+        :return: Results corresponding to handle.
         """
         try:
             return super().get_result(handle)
@@ -500,7 +505,7 @@ using default compilation"
     @cache
     def available_devices(cls, **kwargs: Any) -> list[BackendInfo]:
         """
-        See :py:meth:`pytket.backends.backend.Backend.get_result`.
+        See :py:meth:`pytket.backends.backend.Backend.available_devices`.
 
         Supported kwargs:
 
@@ -511,6 +516,8 @@ using default compilation"
 
         If omitted these are read from config, unless the environment variable
         `AZURE_QUANTUM_CONNECTION_STRING` is set in which case it is used.
+
+        :return: A list of BackendInfo objects describing available devices.
         """
         if kwargs.get("use_string"):
             connection_string = kwargs.get("connection_string")

--- a/pytket/extensions/azure/backends/azure.py
+++ b/pytket/extensions/azure/backends/azure.py
@@ -354,7 +354,7 @@ using default compilation"
           key-value pairs in the dictionary are passed as input parameters to
           the backend. Their semantics are backend-dependent.
 
-        :return: Handles to results for each input circuit, as an interable in
+        :return: Handles to results for each input circuit, as an iterable in
             the same order as the circuits.
         """
         option_params = kwargs.get("option_params")

--- a/pytket/extensions/azure/backends/config.py
+++ b/pytket/extensions/azure/backends/config.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Azure config."""
-
 from dataclasses import dataclass
 from typing import Any, ClassVar
 

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import warnings
 from collections import Counter
 
 import pytest
@@ -46,9 +45,7 @@ def test_ionq_simulator(azure_backend: AzureBackend) -> None:
         counts = r.get_counts()
         assert counts == Counter({(0, 0): 5, (1, 1): 5})
     else:
-        warnings.warn(  # noqa: B028
-            "ionq.simulator unavailable or queue time >= 60s: not submitting"
-        )
+        pytest.skip("ionq.simulator unavailable or queue time >= 60s: not submitting")
 
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
@@ -63,7 +60,7 @@ def test_quantinuum_sim_h11sc(azure_backend: AzureBackend) -> None:
         counts = r.get_counts()
         assert sum(counts.values()) == 1000
     else:
-        warnings.warn(  # noqa: B028
+        pytest.skip(
             "quantinuum.sim.h1-1sc unavailable or queue time >= 60s: not submitting"
         )
 
@@ -93,7 +90,7 @@ def test_quantinuum_sim_h11sc_complex_circuit(azure_backend: AzureBackend) -> No
         counts = r.get_counts()
         assert sum(counts.values()) == 1000
     else:
-        warnings.warn(  # noqa: B028
+        pytest.skip(
             "quantinuum.sim.h1-1sc unavailable or queue time >= 60s: not submitting"
         )
 
@@ -120,7 +117,7 @@ def test_quantinuum_sim_h11sc_complex_circuit_2(azure_backend: AzureBackend) -> 
         counts = r.get_counts()
         assert sum(counts.values()) == 1000
     else:
-        warnings.warn(  # noqa: B028
+        pytest.skip(
             "quantinuum.sim.h1-1sc unavailable or queue time >= 60s: not submitting"
         )
 
@@ -157,7 +154,7 @@ def test_quantinuum_sim_h11sc_complex_circuit_3(azure_backend: AzureBackend) -> 
         counts = r.get_counts()
         assert sum(counts.values()) == 1000
     else:
-        warnings.warn(  # noqa: B028
+        pytest.skip(
             "quantinuum.sim.h1-1sc unavailable or queue time >= 60s: not submitting"
         )
 
@@ -180,7 +177,7 @@ def test_quantinuum_sim_h11sc_two_regs(azure_backend: AzureBackend) -> None:
         counts = r.get_counts()
         assert sum(counts.values()) == 1000
     else:
-        warnings.warn(  # noqa: B028
+        pytest.skip(
             "quantinuum.sim.h1-1sc unavailable or queue time >= 60s: not submitting"
         )
 
@@ -206,7 +203,7 @@ def test_quantinuum_sim_h11sc_reset_gate(azure_backend: AzureBackend) -> None:
         counts = r.get_counts()
         assert sum(counts.values()) == 1000
     else:
-        warnings.warn(  # noqa: B028
+        pytest.skip(
             "quantinuum.sim.h1-1sc unavailable or queue time >= 60s: not submitting"
         )
 
@@ -239,7 +236,7 @@ def test_quantinuum_sim_h11sc_complex(azure_backend: AzureBackend) -> None:
         counts = r.get_counts()
         assert sum(counts.values()) == 1000
     else:
-        warnings.warn(  # noqa: B028
+        pytest.skip(
             "quantinuum.sim.h1-1sc unavailable or queue time >= 60s: not submitting"
         )
 
@@ -276,7 +273,7 @@ def test_quantinuum_sim_h11e_cond(azure_backend: AzureBackend) -> None:
         counts = r.get_counts()
         assert sum(counts.values()) == 1000
     else:
-        warnings.warn(  # noqa: B028
+        pytest.skip(
             "quantinuum.sim.h1-1sc unavailable or queue time >= 60s: not submitting"
         )
 
@@ -349,7 +346,7 @@ def test_quantinuum_sim_h11e_cond_2(azure_backend: AzureBackend) -> None:
         counts = r.get_counts()
         assert sum(counts.values()) == 1000
     else:
-        warnings.warn(  # noqa: B028
+        pytest.skip(
             "quantinuum.sim.h1-1sc unavailable or queue time >= 60s: not submitting"
         )
 
@@ -367,4 +364,4 @@ def test_quantinuum_option_params(azure_backend: AzureBackend) -> None:
         assert all(x[0] == x[1] for x in counts)
         assert any(x[0] == 1 for x in counts)  # might fail in very rare cases
     else:
-        warnings.warn("quantinuum.sim.h1-1e unavailable")  # noqa: B028
+        pytest.skip("quantinuum.sim.h1-1e unavailable")

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -46,7 +46,7 @@ def test_ionq_simulator(azure_backend: AzureBackend) -> None:
         counts = r.get_counts()
         assert counts == Counter({(0, 0): 5, (1, 1): 5})
     else:
-        raise ValueError(
+        warnings.warn(  # noqa: B028
             "ionq.simulator unavailable or queue time >= 60s: not submitting"
         )
 
@@ -63,7 +63,7 @@ def test_quantinuum_sim_h11sc(azure_backend: AzureBackend) -> None:
         counts = r.get_counts()
         assert sum(counts.values()) == 1000
     else:
-        raise ValueError(
+        warnings.warn(  # noqa: B028
             "quantinuum.sim.h1-1sc unavailable or queue time >= 60s: not submitting"
         )
 
@@ -93,7 +93,7 @@ def test_quantinuum_sim_h11sc_complex_circuit(azure_backend: AzureBackend) -> No
         counts = r.get_counts()
         assert sum(counts.values()) == 1000
     else:
-        raise ValueError(
+        warnings.warn(  # noqa: B028
             "quantinuum.sim.h1-1sc unavailable or queue time >= 60s: not submitting"
         )
 
@@ -120,7 +120,7 @@ def test_quantinuum_sim_h11sc_complex_circuit_2(azure_backend: AzureBackend) -> 
         counts = r.get_counts()
         assert sum(counts.values()) == 1000
     else:
-        raise ValueError(
+        warnings.warn(  # noqa: B028
             "quantinuum.sim.h1-1sc unavailable or queue time >= 60s: not submitting"
         )
 
@@ -157,7 +157,7 @@ def test_quantinuum_sim_h11sc_complex_circuit_3(azure_backend: AzureBackend) -> 
         counts = r.get_counts()
         assert sum(counts.values()) == 1000
     else:
-        raise ValueError(
+        warnings.warn(  # noqa: B028
             "quantinuum.sim.h1-1sc unavailable or queue time >= 60s: not submitting"
         )
 
@@ -180,7 +180,7 @@ def test_quantinuum_sim_h11sc_two_regs(azure_backend: AzureBackend) -> None:
         counts = r.get_counts()
         assert sum(counts.values()) == 1000
     else:
-        raise ValueError(
+        warnings.warn(  # noqa: B028
             "quantinuum.sim.h1-1sc unavailable or queue time >= 60s: not submitting"
         )
 
@@ -206,7 +206,7 @@ def test_quantinuum_sim_h11sc_reset_gate(azure_backend: AzureBackend) -> None:
         counts = r.get_counts()
         assert sum(counts.values()) == 1000
     else:
-        raise ValueError(
+        warnings.warn(  # noqa: B028
             "quantinuum.sim.h1-1sc unavailable or queue time >= 60s: not submitting"
         )
 
@@ -239,7 +239,7 @@ def test_quantinuum_sim_h11sc_complex(azure_backend: AzureBackend) -> None:
         counts = r.get_counts()
         assert sum(counts.values()) == 1000
     else:
-        raise ValueError(
+        warnings.warn(  # noqa: B028
             "quantinuum.sim.h1-1sc unavailable or queue time >= 60s: not submitting"
         )
 
@@ -276,7 +276,7 @@ def test_quantinuum_sim_h11e_cond(azure_backend: AzureBackend) -> None:
         counts = r.get_counts()
         assert sum(counts.values()) == 1000
     else:
-        raise ValueError(
+        warnings.warn(  # noqa: B028
             "quantinuum.sim.h1-1sc unavailable or queue time >= 60s: not submitting"
         )
 
@@ -349,7 +349,7 @@ def test_quantinuum_sim_h11e_cond_2(azure_backend: AzureBackend) -> None:
         counts = r.get_counts()
         assert sum(counts.values()) == 1000
     else:
-        raise ValueError(
+        warnings.warn(  # noqa: B028
             "quantinuum.sim.h1-1sc unavailable or queue time >= 60s: not submitting"
         )
 


### PR DESCRIPTION
# Description

Adding CI checks for documentation coverage (making sure that every publicly visible method and class - those whose names don't begin with an underscore - is included in the docs) and enforcing sphinx nitpicky to report any formatting failures and broken cross-references.

This PR also resolves existing gaps in coverage and broken formatting. Some of the newly documented content required for docs coverage may have been intended to be internal components required only as part of the conversion or infrastructure code and is not intended for end users; I will need some help spotting any such instances so we can underscore them out to clarify this intention.

# Related issues

This works towards CQCL/tket#1857, following on from CQCL/tket#1910 for the core package and related PRs for other extensions.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
